### PR TITLE
Correct batch size and thread number for the default constructor in MultistreamBzip2XmlDumpParser.

### DIFF
--- a/src/main/java/se/lth/cs/nlp/mediawiki/parser/MultistreamBzip2XmlDumpParser.java
+++ b/src/main/java/se/lth/cs/nlp/mediawiki/parser/MultistreamBzip2XmlDumpParser.java
@@ -67,7 +67,7 @@ public class MultistreamBzip2XmlDumpParser extends AbstractEmitter<Page,Void> im
      * @param pages the page file contain all the multistreams
      */
     public MultistreamBzip2XmlDumpParser(File index, File pages) {
-        this(index, pages, Runtime.getRuntime().availableProcessors(), 100);
+        this(index, pages, 100, Runtime.getRuntime().availableProcessors());
     }
 
     /**


### PR DESCRIPTION
The parameters were in the wrong order. 
