### PR TITLE
Generate source jar by default and use specific the maven-jar-plugin version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,20 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
It's always nice to have the source to a project and although they easily included with `mvn source:jar install` I'd prefer it included by default.

Got the following warning from maven when installing:
[WARNING]
[WARNING] Some problems were encountered while building the effective model for se.lth.cs.nlp:wikiforia:jar:1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 38, column 15
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]

So I cleaned it up.
![selfie-0](http://i.imgur.com/3GGeFUz.gif)
