### PR TITLE
Fix mix-up of variable names in App.java

### DIFF
--- a/src/main/java/se/lth/cs/nlp/wikiforia/App.java
+++ b/src/main/java/se/lth/cs/nlp/wikiforia/App.java
@@ -149,7 +149,7 @@ public class App
     {
         Source<Page,Void> source;
 
-        if(index == null)
+        if(indexPath == null)
             source = new SinglestreamXmlDumpParser(pagesPath, batchsize);
         else
             source = new MultistreamBzip2XmlDumpParser(indexPath, pagesPath, batchsize, numThreads);
@@ -182,7 +182,7 @@ public class App
     {
         Source<Page,Void> source;
 
-        if(index == null)
+        if(indexPath == null)
             source = new SinglestreamXmlDumpParser(pagesPath, batchsize);
         else
             source = new MultistreamBzip2XmlDumpParser(indexPath, pagesPath, batchsize, numThreads);
@@ -233,7 +233,7 @@ public class App
     {
         Source<Page,Void> source;
 
-        if(index == null)
+        if(indexPath == null)
             source = new SinglestreamXmlDumpParser(pagesPath, batchsize);
         else
             source = new MultistreamBzip2XmlDumpParser(indexPath, pagesPath, batchsize, numThreads);
@@ -297,7 +297,7 @@ public class App
     {
         Source<Page,Void> source;
 
-        if(index == null)
+        if(indexPath == null)
             source = new SinglestreamXmlDumpParser(pagesPath, batchsize);
         else
             source = new MultistreamBzip2XmlDumpParser(indexPath, pagesPath, batchsize, numThreads);
@@ -314,7 +314,7 @@ public class App
                             int batchsize) {
         Source<Page,Void> source;
 
-        if(index == null)
+        if(indexPath == null)
             source = new SinglestreamXmlDumpParser(pagesPath, batchsize);
         else
             source = new MultistreamBzip2XmlDumpParser(indexPath, pagesPath, batchsize, numThreads);


### PR DESCRIPTION
Variable names were mixed-up in .../wikiforia/App.java where
index had been used instead of indexPath to determine whether
to process a multistreamed bzip2 file should be processed or
a singlestreamed xml file. Accordingly the test resolved always
to multistreamed bzip2. This commit fixes the issue.